### PR TITLE
Initialize polling station group on election creation

### DIFF
--- a/src/EligereES/Controllers/ElectionsController.cs
+++ b/src/EligereES/Controllers/ElectionsController.cs
@@ -99,6 +99,7 @@ namespace EligereES.Controllers
             if (ModelState.IsValid)
             {
                 election.Id = Guid.NewGuid();
+                election.PollingStationGroupId = Guid.NewGuid();
                 election.Configuration = _context.ElectionType.Single(q => q.Id == election.ElectionTypeFk).DefaultConfiguration;
                 _context.Add(election);
                 await _context.SaveChangesAsync();


### PR DESCRIPTION
## Summary
- assign a new PollingStationGroupId when creating an election so newly created records always have a group identifier

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f8dea93fb48320bac1bff0b4f790ef